### PR TITLE
Real manifest filtering + summary subtraction for RewriteFilesAction

### DIFF
--- a/crates/iceberg/src/transaction/manifest_filter.rs
+++ b/crates/iceberg/src/transaction/manifest_filter.rs
@@ -18,9 +18,10 @@
 use std::collections::HashSet;
 
 use crate::error::Result;
-use crate::spec::{DataFile, ManifestFile};
+use crate::spec::{DataFile, ManifestFile, ManifestStatus};
 use crate::table::Table;
 use crate::transaction::snapshot::SnapshotProducer;
+use crate::{Error, ErrorKind};
 
 /// Accumulates the set of files an operation removes from a table and rewrites the
 /// affected manifests during manifest production.
@@ -31,13 +32,11 @@ use crate::transaction::snapshot::SnapshotProducer;
 /// and re-emits the survivors.
 ///
 /// **In v1 this always rewrites**: there is no cross-retry rewrite cache (that is deferred
-/// to future work). The rewrite body is a placeholder / pass-through for now — the filter
-/// seam is the normative part. The single `Mutex<MergingCache>` on `MergingSnapshotProducer`
-/// is retained precisely so the deferred cache has a home.
+/// to future work). The single `Mutex<MergingCache>` on `MergingSnapshotProducer` is
+/// retained precisely so the deferred cache has a home.
 #[derive(Default)]
 pub(crate) struct ManifestFilterManager {
     /// Files to drop, keyed by file path. `DataFile` covers both data and delete files.
-    #[allow(dead_code)]
     deleted_files: HashSet<String>,
 }
 
@@ -51,43 +50,447 @@ impl ManifestFilterManager {
         self.deleted_files.insert(file.file_path().to_string());
     }
 
+    /// Returns `true` if the file at `path` is recorded for removal.
+    pub(crate) fn is_removed(&self, path: &str) -> bool {
+        self.deleted_files.contains(path)
+    }
+
     /// Rewrite the given `manifests`, dropping any entries recorded for removal and
-    /// re-emitting the survivors.
+    /// re-emitting the survivors via a producer-provided manifest writer.
     ///
-    /// **v1 always rewrites**: every input manifest goes through the rewrite path
-    /// unconditionally on every attempt — there is no cache lookup/store. The rewrite body
-    /// is a placeholder (pass-through) for now; the filter seam is the normative part.
+    /// Manifests that contain none of the removed files are passed through unchanged, so
+    /// the common (untouched) case costs one manifest read and no write. For each manifest
+    /// that does reference a removed file, a new manifest is written that:
+    ///
+    /// - skips entries already marked [`ManifestStatus::Deleted`] (informational only,
+    ///   never carried forward), and
+    /// - skips entries whose file path is in the removed set.
+    ///
+    /// All remaining live entries are re-emitted as existing entries, preserving their
+    /// original snapshot id and sequence numbers. If a rewrite drops every entry, the
+    /// manifest is omitted from the returned vector entirely.
+    ///
+    /// `fail_missing_delete_paths` mirrors Java's `failMissingDeletePaths`: when `true`,
+    /// every recorded removal must be found among the live entries of the given manifests,
+    /// otherwise the commit fails with `PreconditionFailed`. A rewrite (compaction) sets
+    /// this — committing the *added* half of a rewrite while the *remove* half silently
+    /// no-ops would duplicate every rewritten row.
+    ///
+    /// **v1 always rewrites**: every affected manifest goes through the rewrite path
+    /// unconditionally on every attempt — there is no cross-retry cache (deferred; would
+    /// live in `MergingCache`).
     pub(crate) async fn filter_manifests(
         &self,
         sp: &mut SnapshotProducer<'_>,
         base: &Table,
         manifests: Vec<ManifestFile>,
+        fail_missing_delete_paths: bool,
     ) -> Result<Vec<ManifestFile>> {
-        // TODO(future): cache rewritten manifests per input manifest path to avoid
-        // re-writing (and orphaning) on retry. Deferred from v1; would read/write
-        // MergingCache.filter_cache under a brief lock (never held across IO).
-        let mut out = Vec::with_capacity(manifests.len());
-        for manifest in manifests {
-            // PLACEHOLDER: the real rewrite drops entries in `deleted_files` and re-emits
-            // survivors via `sp`. For now this is effectively pass-through. v1 rewrites
-            // unconditionally on every attempt (no cache short-circuit).
-            let rewritten = self.rewrite_placeholder(sp, base, &manifest).await?;
-            out.extend(rewritten);
+        // Nothing recorded for removal: every manifest is carried forward verbatim.
+        if self.deleted_files.is_empty() {
+            return Ok(manifests);
         }
-        Ok(out)
+
+        // Paths this operation wants to remove but has not yet seen among live entries.
+        // Whatever remains after the loop is missing from the table; with
+        // `fail_missing_delete_paths` that is a commit-stopping error.
+        let mut pending_deletes: HashSet<String> = self.deleted_files.clone();
+
+        let file_io = base.file_io().clone();
+        let default_spec_id = base.metadata().default_partition_spec_id();
+        let mut filtered = Vec::with_capacity(manifests.len());
+
+        for manifest_file in manifests {
+            let manifest = manifest_file.load_manifest(&file_io).await?;
+            let entries = manifest.entries();
+
+            // Pass the manifest through unchanged when none of its live entries reference
+            // a removed file. Deleted entries are ignored for this decision.
+            let has_removed_entry = entries.iter().any(|entry| {
+                entry.status() != ManifestStatus::Deleted && self.is_removed(entry.file_path())
+            });
+            if !has_removed_entry {
+                filtered.push(manifest_file);
+                continue;
+            }
+
+            // `new_manifest_writer` writes with the table's DEFAULT partition spec.
+            // Re-emitting entries whose partition values were shaped by a different spec
+            // would mis-describe their partitioning, so refuse loudly instead. Lifting
+            // this needs a writer parameterized by the source manifest's spec.
+            if manifest_file.partition_spec_id != default_spec_id {
+                return Err(Error::new(
+                    ErrorKind::FeatureUnsupported,
+                    format!(
+                        "Cannot filter manifest written with partition spec {} (table default \
+                         is {}): rewriting entries across partition specs is not supported yet",
+                        manifest_file.partition_spec_id, default_spec_id
+                    ),
+                ));
+            }
+
+            // Rewrite the manifest, re-emitting the survivors as existing entries.
+            let mut writer = sp.new_manifest_writer(manifest_file.content)?;
+            let mut survivors = 0usize;
+            for entry in entries {
+                // Deleted entries are informational only; never carried forward.
+                if entry.status() == ManifestStatus::Deleted {
+                    continue;
+                }
+
+                if self.is_removed(entry.file_path()) {
+                    // Drop the entry: this is the removal actually happening.
+                    pending_deletes.remove(entry.file_path());
+                    continue;
+                }
+
+                writer.add_existing_file(
+                    entry.data_file().clone(),
+                    entry.snapshot_id().unwrap_or_default(),
+                    entry.sequence_number().unwrap_or_default(),
+                    entry.file_sequence_number,
+                )?;
+                survivors += 1;
+            }
+
+            // If every entry was dropped, omit the manifest from the output entirely.
+            if survivors == 0 {
+                continue;
+            }
+
+            filtered.push(writer.write_manifest_file().await?);
+        }
+
+        if fail_missing_delete_paths && !pending_deletes.is_empty() {
+            let mut missing: Vec<&String> = pending_deletes.iter().collect();
+            missing.sort();
+            return Err(Error::new(
+                ErrorKind::PreconditionFailed,
+                format!("Missing required files to delete: {missing:?}"),
+            ));
+        }
+
+        Ok(filtered)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::fs;
+
+    use tempfile::TempDir;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::TableIdent;
+    use crate::io::FileIO;
+    use crate::spec::{
+        DataContentType, DataFileBuilder, DataFileFormat, Literal, ManifestEntry, ManifestStatus,
+        ManifestWriterBuilder, Struct, TableMetadata,
+    };
+    use crate::table::Table;
+    use crate::test_utils::test_runtime;
+    use crate::transaction::snapshot::SnapshotProducer;
+
+    fn data_file(path: &str) -> DataFile {
+        DataFileBuilder::default()
+            .content(DataContentType::Data)
+            .file_path(path.to_string())
+            .file_format(DataFileFormat::Parquet)
+            .file_size_in_bytes(100)
+            .record_count(1)
+            .partition(Struct::from_iter([Some(Literal::long(0))]))
+            .partition_spec_id(0)
+            .build()
+            .unwrap()
     }
 
-    /// Placeholder rewrite body: passes the manifest through unchanged.
-    ///
-    /// The real implementation will load the manifest, drop entries whose file path is in
-    /// `deleted_files`, and re-emit the survivors through a producer-provided manifest
-    /// writer. It is intentionally left as a pass-through in v1.
-    async fn rewrite_placeholder(
-        &self,
-        _sp: &mut SnapshotProducer<'_>,
-        _base: &Table,
-        manifest: &ManifestFile,
-    ) -> Result<Vec<ManifestFile>> {
-        Ok(vec![manifest.clone()])
+    /// Builds a v2 table backed by the local filesystem in a `TempDir`, so manifests can
+    /// be written to and loaded from real files (as `filter_manifests` requires).
+    fn make_fs_table() -> (Table, TempDir) {
+        let tmp_dir = TempDir::new().unwrap();
+        let table_location = tmp_dir.path().join("table1");
+        let manifest_list_location = table_location.join("metadata/manifests_list_1.avro");
+        let table_metadata_location = table_location.join("metadata/v1.json");
+
+        let file_io = FileIO::new_with_fs();
+
+        let template = fs::read_to_string(format!(
+            "{}/testdata/example_table_metadata_v2.json",
+            env!("CARGO_MANIFEST_DIR")
+        ))
+        .unwrap();
+        let metadata_json = template
+            .replace("{{ table_location }}", table_location.to_str().unwrap())
+            .replace(
+                "{{ manifest_list_1_location }}",
+                manifest_list_location.to_str().unwrap(),
+            )
+            .replace(
+                "{{ manifest_list_2_location }}",
+                manifest_list_location.to_str().unwrap(),
+            )
+            .replace(
+                "{{ table_metadata_1_location }}",
+                table_metadata_location.to_str().unwrap(),
+            );
+        let table_metadata = serde_json::from_str::<TableMetadata>(&metadata_json).unwrap();
+
+        let table = Table::builder()
+            .metadata(table_metadata)
+            .identifier(TableIdent::from_strs(["db", "table1"]).unwrap())
+            .file_io(file_io)
+            .metadata_location(table_metadata_location.to_str().unwrap())
+            .runtime(test_runtime())
+            .build()
+            .unwrap();
+
+        (table, tmp_dir)
+    }
+
+    fn make_producer<'a>(table: &'a Table) -> SnapshotProducer<'a> {
+        SnapshotProducer::builder()
+            .table(table)
+            .commit_uuid(Uuid::now_v7())
+            .snapshot_properties(HashMap::new())
+            .added_data_files(vec![])
+            .build()
+    }
+
+    /// Writes a data manifest to disk containing one `Added` data entry per path in
+    /// `paths` and returns the resulting [`ManifestFile`].
+    async fn write_data_manifest(table: &Table, paths: &[&str]) -> ManifestFile {
+        let current_snapshot = table.metadata().current_snapshot().unwrap();
+        let schema = current_snapshot.schema(table.metadata()).unwrap();
+        let partition_spec = table.metadata().default_partition_spec();
+        let table_location_str = table.metadata().location().to_string();
+
+        let output_file = table
+            .file_io()
+            .new_output(format!(
+                "{table_location_str}/metadata/manifest_{}.avro",
+                Uuid::new_v4()
+            ))
+            .unwrap();
+
+        let mut writer = ManifestWriterBuilder::new(
+            output_file,
+            Some(current_snapshot.snapshot_id()),
+            schema.clone(),
+            partition_spec.as_ref().clone(),
+        )
+        .build_v2_data();
+
+        for path in paths {
+            writer
+                .add_entry(
+                    ManifestEntry::builder()
+                        .status(ManifestStatus::Added)
+                        .data_file(
+                            DataFileBuilder::default()
+                                .partition_spec_id(0)
+                                .content(DataContentType::Data)
+                                .file_path(path.to_string())
+                                .file_format(DataFileFormat::Parquet)
+                                .file_size_in_bytes(100)
+                                .record_count(1)
+                                .partition(Struct::from_iter([Some(Literal::long(100))]))
+                                .build()
+                                .unwrap(),
+                        )
+                        .build(),
+                )
+                .unwrap();
+        }
+
+        writer.write_manifest_file().await.unwrap()
+    }
+
+    /// Collects the file paths of all alive entries in a manifest on disk.
+    async fn manifest_file_paths(table: &Table, manifest_file: &ManifestFile) -> Vec<String> {
+        let manifest = manifest_file.load_manifest(table.file_io()).await.unwrap();
+        manifest
+            .entries()
+            .iter()
+            .filter(|entry| entry.status() != ManifestStatus::Deleted)
+            .map(|entry| entry.file_path().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn test_delete_file_records_removal_by_path_and_dedupes() {
+        let mut manager = ManifestFilterManager::default();
+        manager.delete_file(data_file("test/1.parquet"));
+        manager.delete_file(data_file("test/1.parquet"));
+
+        assert!(manager.is_removed("test/1.parquet"));
+        assert!(!manager.is_removed("test/2.parquet"));
+        assert_eq!(manager.deleted_files.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_filter_manifests_no_op_when_nothing_removed() {
+        let (table, _tmp_dir) = make_fs_table();
+        let manifest = write_data_manifest(&table, &["data/a.parquet", "data/b.parquet"]).await;
+        let mut producer = make_producer(&table);
+
+        // Nothing recorded for removal: the manifest must be returned verbatim.
+        let manager = ManifestFilterManager::default();
+        let result = manager
+            .filter_manifests(&mut producer, &table, vec![manifest.clone()], true)
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].manifest_path, manifest.manifest_path);
+    }
+
+    #[tokio::test]
+    async fn test_filter_manifests_untouched_manifest_passes_through_unchanged() {
+        let (table, _tmp_dir) = make_fs_table();
+        let touched = write_data_manifest(&table, &["data/a.parquet", "data/b.parquet"]).await;
+        let untouched = write_data_manifest(&table, &["data/x.parquet"]).await;
+        let mut producer = make_producer(&table);
+
+        let mut manager = ManifestFilterManager::default();
+        manager.delete_file(data_file("data/a.parquet"));
+
+        let result = manager
+            .filter_manifests(
+                &mut producer,
+                &table,
+                vec![touched.clone(), untouched.clone()],
+                true,
+            )
+            .await
+            .unwrap();
+
+        // The untouched manifest is carried forward verbatim (same path — no rewrite);
+        // the touched one is rewritten to a new path.
+        assert_eq!(result.len(), 2);
+        assert_ne!(result[0].manifest_path, touched.manifest_path);
+        assert_eq!(result[1].manifest_path, untouched.manifest_path);
+    }
+
+    #[tokio::test]
+    async fn test_filter_manifests_removing_all_entries_drops_manifest() {
+        let (table, _tmp_dir) = make_fs_table();
+        let manifest = write_data_manifest(&table, &["data/a.parquet", "data/b.parquet"]).await;
+        let mut producer = make_producer(&table);
+
+        let mut manager = ManifestFilterManager::default();
+        manager.delete_file(data_file("data/a.parquet"));
+        manager.delete_file(data_file("data/b.parquet"));
+
+        let result = manager
+            .filter_manifests(&mut producer, &table, vec![manifest], true)
+            .await
+            .unwrap();
+
+        // The manifest is dropped from the output entirely once all entries are removed.
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_filter_manifests_removing_subset_rewrites_survivors_as_existing() {
+        let (table, _tmp_dir) = make_fs_table();
+        let original = write_data_manifest(&table, &[
+            "data/a.parquet",
+            "data/b.parquet",
+            "data/c.parquet",
+        ])
+        .await;
+        let mut producer = make_producer(&table);
+
+        let mut manager = ManifestFilterManager::default();
+        manager.delete_file(data_file("data/b.parquet"));
+
+        let result = manager
+            .filter_manifests(&mut producer, &table, vec![original.clone()], true)
+            .await
+            .unwrap();
+
+        // A rewritten manifest is produced (distinct from the original) holding survivors.
+        assert_eq!(result.len(), 1);
+        assert_ne!(result[0].manifest_path, original.manifest_path);
+
+        let mut survivors = manifest_file_paths(&table, &result[0]).await;
+        survivors.sort();
+        assert_eq!(survivors, vec![
+            "data/a.parquet".to_string(),
+            "data/c.parquet".to_string(),
+        ]);
+
+        // Survivors are re-emitted as EXISTING entries, never re-added.
+        let manifest = result[0].load_manifest(table.file_io()).await.unwrap();
+        assert!(
+            manifest
+                .entries()
+                .iter()
+                .all(|e| e.status() == ManifestStatus::Existing)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_missing_delete_path_fails_when_required() {
+        let (table, _tmp_dir) = make_fs_table();
+        // The manifest holds a+b; the operation wants to remove b AND a file that is
+        // nowhere in the table (already rewritten away by a concurrent commit).
+        let manifest = write_data_manifest(&table, &["data/a.parquet", "data/b.parquet"]).await;
+        let mut producer = make_producer(&table);
+
+        let mut manager = ManifestFilterManager::default();
+        manager.delete_file(data_file("data/b.parquet"));
+        manager.delete_file(data_file("data/vanished.parquet"));
+
+        let err = manager
+            .filter_manifests(&mut producer, &table, vec![manifest], true)
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::PreconditionFailed);
+        assert!(err.to_string().contains("data/vanished.parquet"));
+    }
+
+    #[tokio::test]
+    async fn test_missing_delete_path_tolerated_when_not_required() {
+        let (table, _tmp_dir) = make_fs_table();
+        let manifest = write_data_manifest(&table, &["data/a.parquet", "data/b.parquet"]).await;
+        let mut producer = make_producer(&table);
+
+        let mut manager = ManifestFilterManager::default();
+        manager.delete_file(data_file("data/b.parquet"));
+        manager.delete_file(data_file("data/vanished.parquet"));
+
+        // Same situation, but the operation does not require all removals to exist.
+        let result = manager
+            .filter_manifests(&mut producer, &table, vec![manifest], false)
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        let survivors = manifest_file_paths(&table, &result[0]).await;
+        assert_eq!(survivors, vec!["data/a.parquet".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn test_filter_refuses_manifest_from_a_different_partition_spec() {
+        let (table, _tmp_dir) = make_fs_table();
+        let mut manifest = write_data_manifest(&table, &["data/a.parquet"]).await;
+        // Simulate a manifest written under an older partition spec: rewriting its
+        // entries with the default spec would mis-describe their partitioning.
+        manifest.partition_spec_id = 99;
+        let mut producer = make_producer(&table);
+
+        let mut manager = ManifestFilterManager::default();
+        manager.delete_file(data_file("data/a.parquet"));
+
+        let err = manager
+            .filter_manifests(&mut producer, &table, vec![manifest], true)
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::FeatureUnsupported);
     }
 }

--- a/crates/iceberg/src/transaction/merging_snapshot.rs
+++ b/crates/iceberg/src/transaction/merging_snapshot.rs
@@ -186,11 +186,15 @@ impl MergingSnapshotProducer {
     ///
     /// `base` is the refreshed base table (`sp.table`); it is threaded through to the filter
     /// managers for manifest IO.
+    /// `fail_missing_delete_paths` mirrors Java's `failMissingDeletePaths`: when `true`,
+    /// every staged removal must still exist among the live entries — a rewrite sets this
+    /// so it can never commit its added files while the removals silently no-op.
     pub(crate) async fn filter_existing_manifests(
         &self,
         sp: &mut SnapshotProducer<'_>,
         base: &Table,
         manifests: Vec<ManifestFile>,
+        fail_missing_delete_paths: bool,
     ) -> Result<Vec<ManifestFile>> {
         let (data_manifests, delete_manifests): (Vec<ManifestFile>, Vec<ManifestFile>) = manifests
             .into_iter()
@@ -198,11 +202,11 @@ impl MergingSnapshotProducer {
 
         let mut filtered = self
             .data_filter
-            .filter_manifests(sp, base, data_manifests)
+            .filter_manifests(sp, base, data_manifests, fail_missing_delete_paths)
             .await?;
         let filtered_deletes = self
             .delete_filter
-            .filter_manifests(sp, base, delete_manifests)
+            .filter_manifests(sp, base, delete_manifests, fail_missing_delete_paths)
             .await?;
         filtered.extend(filtered_deletes);
         Ok(filtered)

--- a/crates/iceberg/src/transaction/mod.rs
+++ b/crates/iceberg/src/transaction/mod.rs
@@ -58,6 +58,8 @@ mod expire_snapshots;
 mod manifest_filter;
 mod merging_snapshot;
 mod rewrite_files;
+#[cfg(test)]
+mod rewrite_files_e2e_test;
 mod snapshot;
 mod sort_order;
 mod update_location;

--- a/crates/iceberg/src/transaction/rewrite_files.rs
+++ b/crates/iceberg/src/transaction/rewrite_files.rs
@@ -158,6 +158,16 @@ impl SnapshotProduceOperation for RewriteFilesOperation<'_> {
         Operation::Replace
     }
 
+    /// The staged removals, so the snapshot summary subtracts what the rewrite
+    /// dropped — without this the `total-*` fields over-count every removed
+    /// file forever (caught live: a 4-file→1-file rewrite reported
+    /// `total-data-files=5, total-records=400` on a 200-row table).
+    fn removed_files(&self) -> &[DataFile] {
+        // P1: rewrite removes data files; removed delete files are accounted
+        // when delete-file rewrites land.
+        self.msp.deleted_data_files()
+    }
+
     async fn delete_entries(
         &self,
         _snapshot_produce: &SnapshotProducer<'_>,

--- a/crates/iceberg/src/transaction/rewrite_files.rs
+++ b/crates/iceberg/src/transaction/rewrite_files.rs
@@ -217,8 +217,12 @@ impl SnapshotProduceOperation for RewriteFilesOperation<'_> {
         let manifest_list = base.manifest_list_reader(snapshot).load().await?;
         let manifests = manifest_list.entries().to_vec();
 
+        // A rewrite REQUIRES every file it removes to still exist (Java parity:
+        // `failMissingDeletePaths`). If a removal target vanished — e.g. a concurrent
+        // rewrite already replaced it — committing our added files anyway would
+        // duplicate every row they carry.
         self.msp
-            .filter_existing_manifests(snapshot_produce, base, manifests)
+            .filter_existing_manifests(snapshot_produce, base, manifests, true)
             .await
     }
 }

--- a/crates/iceberg/src/transaction/rewrite_files_e2e_test.rs
+++ b/crates/iceberg/src/transaction/rewrite_files_e2e_test.rs
@@ -1,0 +1,275 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! End-to-end tests for `RewriteFilesAction` against a filesystem-backed
+//! `MemoryCatalog`: append small files across snapshots, rewrite them into a
+//! merged file, and verify the committed `Replace` snapshot serves ONLY the
+//! merged file.
+//!
+//! The regression these tests pin: committing a compaction as a plain append
+//! leaves the source files live in the new snapshot and every rewritten row is
+//! served twice. A `RewriteFiles` commit must atomically add the merged file
+//! AND remove its sources.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arrow_array::{ArrayRef, Int64Array, RecordBatch};
+use futures::TryStreamExt;
+use parquet::file::properties::WriterProperties;
+use tempfile::TempDir;
+
+use crate::memory::{MEMORY_CATALOG_WAREHOUSE, MemoryCatalogBuilder};
+use crate::spec::{DataFile, ManifestStatus, NestedField, Operation, PrimitiveType, Schema, Type};
+use crate::transaction::{ApplyTransactionAction, Transaction};
+use crate::writer::base_writer::data_file_writer::DataFileWriterBuilder;
+use crate::writer::file_writer::ParquetWriterBuilder;
+use crate::writer::file_writer::location_generator::{
+    DefaultFileNameGenerator, DefaultLocationGenerator,
+};
+use crate::writer::file_writer::rolling_writer::RollingFileWriterBuilder;
+use crate::writer::{IcebergWriter, IcebergWriterBuilder};
+use crate::{Catalog, CatalogBuilder, ErrorKind, NamespaceIdent, TableCreation, TableIdent};
+
+/// A catalog + table with schema `(id: long)`, warehoused in a fresh `TempDir`.
+async fn fs_catalog_and_table() -> (Arc<dyn Catalog>, crate::table::Table, TempDir) {
+    let tmp = TempDir::new().unwrap();
+    let catalog = MemoryCatalogBuilder::default()
+        .load(
+            "memory",
+            HashMap::from([(
+                MEMORY_CATALOG_WAREHOUSE.to_string(),
+                format!("file://{}", tmp.path().to_str().unwrap()),
+            )]),
+        )
+        .await
+        .unwrap();
+
+    let ns = NamespaceIdent::new("compaction".to_string());
+    catalog.create_namespace(&ns, HashMap::new()).await.unwrap();
+
+    let schema = Schema::builder()
+        .with_schema_id(0)
+        .with_fields(vec![
+            NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long)).into(),
+        ])
+        .build()
+        .unwrap();
+
+    let table = catalog
+        .create_table(
+            &ns,
+            TableCreation::builder()
+                .name("c12_regression".to_string())
+                .schema(schema)
+                .build(),
+        )
+        .await
+        .unwrap();
+
+    (Arc::new(catalog) as Arc<dyn Catalog>, table, tmp)
+}
+
+/// Write `ids` into a single Parquet data file for `table` and return its `DataFile`.
+async fn write_data_file(table: &crate::table::Table, ids: &[i64]) -> DataFile {
+    let location_gen = DefaultLocationGenerator::new(table.metadata()).unwrap();
+    let file_name_gen = DefaultFileNameGenerator::new(
+        "e2e".to_string(),
+        Some(uuid::Uuid::now_v7().to_string()),
+        crate::spec::DataFileFormat::Parquet,
+    );
+    let parquet_builder = ParquetWriterBuilder::new(
+        WriterProperties::default(),
+        table.metadata().current_schema().clone(),
+    );
+    let rolling_builder = RollingFileWriterBuilder::new_with_default_file_size(
+        parquet_builder,
+        table.file_io().clone(),
+        location_gen,
+        file_name_gen,
+    );
+    let mut writer = DataFileWriterBuilder::new(rolling_builder)
+        .build(None)
+        .await
+        .unwrap();
+
+    let arrow_schema =
+        Arc::new(crate::arrow::schema_to_arrow_schema(table.metadata().current_schema()).unwrap());
+    let batch = RecordBatch::try_new(arrow_schema, vec![
+        Arc::new(Int64Array::from(ids.to_vec())) as ArrayRef
+    ])
+    .unwrap();
+    writer.write(batch).await.unwrap();
+    let mut files = writer.close().await.unwrap();
+    assert_eq!(files.len(), 1, "expected exactly one data file");
+    files.pop().unwrap()
+}
+
+/// Append `file` to `table` in its own snapshot and return the refreshed table.
+async fn append_one(
+    catalog: &Arc<dyn Catalog>,
+    table: crate::table::Table,
+    file: DataFile,
+) -> crate::table::Table {
+    let tx = Transaction::new(&table);
+    let append = tx.fast_append().add_data_files(vec![file]);
+    let tx = append.apply(tx).unwrap();
+    tx.commit(catalog.as_ref()).await.unwrap()
+}
+
+/// All live (non-deleted) data file paths reachable from the current snapshot.
+async fn live_file_paths(table: &crate::table::Table) -> Vec<String> {
+    let snapshot = table.metadata().current_snapshot().unwrap();
+    let manifest_list = table.manifest_list_reader(snapshot).load().await.unwrap();
+    let mut paths = Vec::new();
+    for manifest_file in manifest_list.entries() {
+        let manifest = manifest_file.load_manifest(table.file_io()).await.unwrap();
+        for entry in manifest.entries() {
+            if entry.status() != ManifestStatus::Deleted {
+                paths.push(entry.file_path().to_string());
+            }
+        }
+    }
+    paths.sort();
+    paths
+}
+
+/// Total rows served by scanning the current table state.
+async fn scan_row_count(table: &crate::table::Table) -> usize {
+    let batches: Vec<RecordBatch> = table
+        .scan()
+        .select_all()
+        .build()
+        .unwrap()
+        .to_arrow()
+        .await
+        .unwrap()
+        .try_collect()
+        .await
+        .unwrap();
+    batches.iter().map(|b| b.num_rows()).sum()
+}
+
+#[tokio::test]
+async fn rewrite_commit_replaces_sources_with_merged_file() {
+    let (catalog, table, _tmp) = fs_catalog_and_table().await;
+
+    // Two append snapshots of two rows each — the "small files" of a compaction.
+    let file_a = write_data_file(&table, &[1, 2]).await;
+    let file_b = write_data_file(&table, &[3, 4]).await;
+    let path_a = file_a.file_path().to_string();
+    let path_b = file_b.file_path().to_string();
+    let table = append_one(&catalog, table, file_a).await;
+    let table = append_one(&catalog, table, file_b).await;
+    assert_eq!(scan_row_count(&table).await, 4);
+
+    // The rewrite: one merged file carrying the union of the source rows.
+    let merged = write_data_file(&table, &[1, 2, 3, 4]).await;
+    let merged_path = merged.file_path().to_string();
+
+    // Removal set: the two source files, re-read from the current snapshot the
+    // way a real compactor discovers them.
+    let sources: Vec<DataFile> = {
+        let snapshot = table.metadata().current_snapshot().unwrap();
+        let manifest_list = table.manifest_list_reader(snapshot).load().await.unwrap();
+        let mut found = Vec::new();
+        for manifest_file in manifest_list.entries() {
+            let manifest = manifest_file.load_manifest(table.file_io()).await.unwrap();
+            for entry in manifest.entries() {
+                if entry.status() != ManifestStatus::Deleted {
+                    found.push(entry.data_file().clone());
+                }
+            }
+        }
+        found
+    };
+    assert_eq!(sources.len(), 2);
+
+    let tx = Transaction::new(&table);
+    let rewrite = tx
+        .rewrite_files()
+        .add_files(vec![merged])
+        .unwrap()
+        .delete_files(sources)
+        .unwrap();
+    let tx = rewrite.apply(tx).unwrap();
+    let table = tx.commit(catalog.as_ref()).await.unwrap();
+
+    // The committed snapshot is a REPLACE...
+    let snapshot = table.metadata().current_snapshot().unwrap();
+    assert_eq!(snapshot.summary().operation, Operation::Replace);
+
+    // ...that serves ONLY the merged file. The c12 regression (fast_append-as-
+    // compaction) would leave path_a/path_b live here and double every row.
+    let live = live_file_paths(&table).await;
+    assert_eq!(live, vec![merged_path.clone()]);
+    assert!(!live.contains(&path_a));
+    assert!(!live.contains(&path_b));
+
+    // Row count is preserved, not doubled.
+    assert_eq!(scan_row_count(&table).await, 4);
+}
+
+#[tokio::test]
+async fn rewrite_commit_fails_when_a_source_file_is_missing() {
+    let (catalog, table, _tmp) = fs_catalog_and_table().await;
+
+    let file_a = write_data_file(&table, &[1, 2]).await;
+    let table = append_one(&catalog, table, file_a).await;
+
+    // The removal names a file that is not in the table (e.g. already rewritten
+    // by a concurrent compaction). Committing the ADD half anyway would
+    // duplicate rows — the commit must refuse.
+    let merged = write_data_file(&table, &[1, 2]).await;
+    let phantom = write_data_file(&table, &[9]).await; // written but never appended
+
+    let tx = Transaction::new(&table);
+    let rewrite = tx
+        .rewrite_files()
+        .add_files(vec![merged])
+        .unwrap()
+        .delete_files(vec![phantom])
+        .unwrap();
+    let tx = rewrite.apply(tx).unwrap();
+    let err = tx.commit(catalog.as_ref()).await.unwrap_err();
+
+    assert_eq!(err.kind(), ErrorKind::PreconditionFailed);
+    assert!(err.to_string().contains("Missing required files to delete"));
+
+    // And the table is untouched: still exactly one live file, two rows.
+    let table = catalog
+        .load_table(&TableIdent::from_strs(["compaction", "c12_regression"]).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(live_file_paths(&table).await.len(), 1);
+    assert_eq!(scan_row_count(&table).await, 2);
+}
+
+#[tokio::test]
+async fn rewrite_with_nothing_to_delete_is_rejected() {
+    let (catalog, table, _tmp) = fs_catalog_and_table().await;
+    let file_a = write_data_file(&table, &[1]).await;
+    let table = append_one(&catalog, table, file_a).await;
+
+    // A "rewrite" that only adds is an append wearing a costume — reject it.
+    let extra = write_data_file(&table, &[2]).await;
+    let tx = Transaction::new(&table);
+    let rewrite = tx.rewrite_files().add_files(vec![extra]).unwrap();
+    let tx = rewrite.apply(tx).unwrap();
+    let err = tx.commit(catalog.as_ref()).await.unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::DataInvalid);
+}

--- a/crates/iceberg/src/transaction/rewrite_files_e2e_test.rs
+++ b/crates/iceberg/src/transaction/rewrite_files_e2e_test.rs
@@ -222,6 +222,18 @@ async fn rewrite_commit_replaces_sources_with_merged_file() {
 
     // Row count is preserved, not doubled.
     assert_eq!(scan_row_count(&table).await, 4);
+
+    // The summary's totals must subtract the removed files — caught live: a
+    // rewrite that only fed added files into the collector reported
+    // total-data-files=5 / total-records=400 for this exact shape.
+    let props = &snapshot.summary().additional_properties;
+    assert_eq!(props.get("total-data-files").map(String::as_str), Some("1"));
+    assert_eq!(props.get("total-records").map(String::as_str), Some("4"));
+    assert_eq!(
+        props.get("deleted-data-files").map(String::as_str),
+        Some("2")
+    );
+    assert_eq!(props.get("deleted-records").map(String::as_str), Some("4"));
 }
 
 #[tokio::test]

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -83,6 +83,14 @@ pub(crate) trait SnapshotProduceOperation: Send + Sync {
         parent_snapshot_id: Option<i64>,
     ) -> impl Future<Output = Result<()>> + Send;
 
+    /// Files this operation removes from the table, for snapshot-summary
+    /// accounting (`deleted-*`/`removed-*` and the `total-*` subtraction).
+    /// Default: none. Delete-class operations MUST override this or the new
+    /// snapshot's totals silently over-count everything they removed.
+    fn removed_files(&self) -> &[DataFile] {
+        &[]
+    }
+
     /// Returns manifest entries that should be marked as deleted in the new snapshot.
     #[allow(unused)]
     fn delete_entries(
@@ -426,6 +434,13 @@ impl<'a> SnapshotProducer<'a> {
 
         for data_file in &self.added_data_files {
             summary_collector.add_file(
+                data_file,
+                table_metadata.current_schema().clone(),
+                table_metadata.default_partition_spec().clone(),
+            );
+        }
+        for data_file in snapshot_produce_operation.removed_files() {
+            summary_collector.remove_file(
                 data_file,
                 table_metadata.current_schema().clone(),
                 table_metadata.default_partition_spec().clone(),


### PR DESCRIPTION
Hi @CTTY — following up on my comment on apache/iceberg-rust#2620, here are the two commits as a PR into your branch so they're easy to absorb — merge, cherry-pick, or just use as reference, your call entirely.

The first commit replaces the placeholder ManifestFilterManager with real filtering: untouched manifests pass through, affected ones are rewritten with removed entries dropped and survivors re-emitted as EXISTING (original snapshot and sequence numbers preserved), and rewrites run with `fail_missing_delete_paths=true`, mirroring Java and brgr-s's earlier suggestion. Manifests from a non-default partition spec are refused for now rather than silently mishandled.

The second commit fixes snapshot summary totals for replace operations: `SnapshotProducer::summary()` only saw added files, so totals over-count after a rewrite, and because totals chain, the error becomes permanent in every later snapshot. It adds a `removed_files()` hook so the summary collector subtracts.

Tested with unit tests plus an end-to-end run against a REST catalog and S3, cross-checked from Trino — row counts, live file count, and summary fields all match. Happy to reshape any of this however you prefer.
